### PR TITLE
Add HTML

### DIFF
--- a/lib/languages.js
+++ b/lib/languages.js
@@ -71,5 +71,6 @@ module.exports = {
   ".eg":          {"name": "earl-grey", "symbol": ";;"},
   ".jade":        {"name": "jade", "symbol": "//"},
   ".styl":        {"name": "stylus", "symbol": "//"},
-  ".ts":          {"name": "typescript", "symbol": "//", "block": cBlock}
+  ".ts":          {"name": "typescript", "symbol": "//", "block": cBlock},
+  ".html":        {"name": "html", "symbol": "//", "block": {"start": "<!--", "end": "-->", "ignore": "-"} }
 };


### PR DESCRIPTION
I know there already was a PR about this but this small change makes the plugin to work with this cases:

```language-html
<!-- TODO this is an html comment -->
// TODO this is a line comment inside an html
```

That would only leave one last case to be finished:

```language-html
/*
* TODO this is a block comment inside an html
*/
```