### PR TITLE
Don’t add a priority to tasks that don’t already have one. (Closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ Task formats
 
 ### Hash Style
 <pre>
+&#35;TODO: This is a task
 &#35;TODO:0 This is a task
 &#35;to-do:0 This is a task
 </pre>
 
 ### Markdown Style
 <pre>
+&#91;This is a task&#93;&#40;&#35;todo&#41;
 &#91;This is a task&#93;&#40;&#35;todo:10&#41;
 </pre>
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,7 @@ module.exports = {
   DEFAULT_CONFIG: {
     exclude: [DEFAULT_EXCLUDE_PATTERN],
     watcher: true,
+    keepEmptyPriority: false,
     code: {
       include_lists:[
         "TODO", "DOING", "DONE", "PLANNING", "FIXME", "ARCHIVE", "HACK", "CHANGED", "XXX", "IDEA", "NOTE", "REVIEW"

--- a/lib/file.js
+++ b/lib/file.js
@@ -328,7 +328,7 @@ File.prototype.extractCodeStyleTasks = function(config, pos, content) {
       var list = result[1];
       if (config && !config.includeList(list)) return; // #BACKLOG:20 Save all lists found so we can present them to the user
       var rawTask = result[0];
-      var order = (result[2] === undefined) ? 0 : parseFloat(result[2]);
+      var order = (result[2] === undefined) ? "" : parseFloat(result[2]);
       var text = result[3];
       var line = this.getLineNumber(posInContent);
       var task = self.newTask(list, text, order, line, Task.Types.CODE);
@@ -345,7 +345,7 @@ File.prototype.extractHashStyleTasks = function(pos, content) {
   while((result = hashStyleRegex.exec(content)) !== null) {
     var list = result[1];
     var rawTask = result[0];
-    var order = (result[2] === undefined) ? 0 : parseFloat(result[2]);
+    var order = (result[2] === undefined) ? "" : parseFloat(result[2]);
     var text = result[3];
     var line = this.getLineNumber(result.index + pos);
     var task = this.newTask(list, text, order, line, Task.Types.HASHTAG);
@@ -361,7 +361,7 @@ File.prototype.extractLinkStyleTasks = function(pos, content) {
   while((result = linkStyleRegex.exec(content)) !== null) {
     var list = result[2];
     var rawTask = result[0];
-    var order = (result[3] === undefined) ? 0 : parseFloat(result[3]);
+    var order = (result[3] === undefined) ? "" : parseFloat(result[3]);
     var text = result[1];
     var line = this.getLineNumber(result.index + pos);
     log("*********************************************************");
@@ -466,7 +466,11 @@ File.prototype.modifyCodeOrHashTask = function(re, task) {
         } else text = task.text;
       } else text = task.text;
       var hash = task.type === Task.Types.HASHTAG ? "#" : "";
-      var taskContent = util.format("%s%s:%d %s", hash, task.list, task.order, text);
+      var taskContent;
+      if ( task.order !== "" )
+        taskContent = util.format("%s%s:%d %s", hash, task.list, task.order, text);
+      else
+        taskContent = util.format("%s%s %s", hash, task.list, text);
       this.setContent(beforeContent + taskContent + afterContent);
       this.setModified(true);
       // task.type = Task.Types.HASHTAG;
@@ -501,7 +505,11 @@ File.prototype.modifyLinkTask = function(task) {
     if (task.id == getTaskId(self.getPath(),line, text)) {
       var beforeContent = this.getContent().substring(0, result.index);
       var afterContent = this.getContent().substring(re.lastIndex);
-      var taskContent = util.format("[%s](#%s:%d)", task.text, task.list, task.order);
+      var taskContent;
+      if ( task.order !== "" )
+         taskContent = util.format("[%s](#%s:%d)", task.text, task.list, task.order);
+      else
+        taskContent = util.format("[%s](#%s)", task.text, task.list );
       this.setContent(beforeContent + taskContent + afterContent);
       this.removeTask(task);
       this.setModified(true);
@@ -543,7 +551,7 @@ File.prototype.extractTasks = function(config) {
   if (!this.getContent()) throw new Error("Load content with Repository.readFileContent");
   cb = tools.cb(cb);
   var content = this.getContent().replace(new RegExp(HASH_STYLE_REGEX), function(md, list, order, text, pos) {
-    order = (order === undefined) ? "0" : order;
+    order = (order === undefined) ? "" : order;
     return util.format(" [%s](#%s:%s)", text, list, order);
   });
   marked(content, opts, cb);

--- a/lib/file.js
+++ b/lib/file.js
@@ -51,7 +51,7 @@ util.inherits(File, events.EventEmitter);
 var LINK_STYLE_REGEX = File.LINK_STYLE_REGEX = /\[(.+?)\]\(#([\w\-]+?):(\d+?\.?\d*?)\)/gm;
 var CODE_BLOCK_REGEX = File.CODE_BLOCK_REGEX = /`{3}[\s\S]*?`{3}/gm;
 var INLINE_CODE_REGEX = File.INLINE_CODE_REGEX = /`[\s\S]*?`/g;
-var CODE_STYLE_PATTERN = File.CODE_STYLE_PATTERN = "([A-Z]{2,}):?(\\d+?\\.?\\d*?)?\\s+(.*)$";
+var CODE_STYLE_PATTERN = File.CODE_STYLE_PATTERN = "([A-Z]{2,})((:)(\\d+?\\.?\\d*?)?)?\\s+(.*)$";
 var HASH_STYLE_REGEX = File.HASH_STYLE_REGEX = /#([\w\-]+?):(\d+?\.?\d*?)\s+(.*)$/gm;
 
 var getTaskId = File.getTaskId = function(path, line, text) {
@@ -277,12 +277,13 @@ File.prototype.isCodeFile = function() {
   return (symbol && symbol !== "");
 };
 
-File.prototype.newTask = function(list, text, order, line, type) {
+File.prototype.newTask = function(list, text, order, line, type, hasColon) {
   var self = this;
   text = self.trimCodeBlockEnd(text);
   var task = new Task({
     text: text,
     list: list,
+    hasColon: hasColon,
     order: order,
     line: line,
     id: getTaskId(self.getPath(), line, text),
@@ -328,10 +329,11 @@ File.prototype.extractCodeStyleTasks = function(config, pos, content) {
       var list = result[1];
       if (config && !config.includeList(list)) return; // #BACKLOG:20 Save all lists found so we can present them to the user
       var rawTask = result[0];
-      var order = (result[2] === undefined) ? "" : parseFloat(result[2]);
-      var text = result[3];
+      var hasColon = ( result[3] !== undefined );
+      var order = (result[4] === undefined) ? "" : parseFloat(result[4]);
+      var text = result[5];
       var line = this.getLineNumber(posInContent);
-      var task = self.newTask(list, text, order, line, Task.Types.CODE);
+      var task = self.newTask(list, text, order, line, Task.Types.CODE, hasColon);
       self.addTask(task);
       self.emit("task.found", task);
     }
@@ -348,7 +350,7 @@ File.prototype.extractHashStyleTasks = function(pos, content) {
     var order = (result[2] === undefined) ? "" : parseFloat(result[2]);
     var text = result[3];
     var line = this.getLineNumber(result.index + pos);
-    var task = this.newTask(list, text, order, line, Task.Types.HASHTAG);
+    var task = this.newTask(list, text, order, line, Task.Types.HASHTAG, true);
     self.addTask(task);
     self.emit("task.found", task);
   }
@@ -366,7 +368,7 @@ File.prototype.extractLinkStyleTasks = function(pos, content) {
     var line = this.getLineNumber(result.index + pos);
     log("*********************************************************");
     log("list:%s text:%s order:%d line:%d", list, text, order, line);
-    var task = self.newTask(list, text, order, line, Task.Types.MARKDOWN);
+    var task = self.newTask(list, text, order, line, Task.Types.MARKDOWN, true);
     self.addTask(task);
     self.emit("task.found", task);
   }
@@ -451,7 +453,7 @@ File.prototype.modifyCodeOrHashTask = function(re, task) {
     log('Got result: %j', result);
     var rawTask = result[0];
     var list = result[1];
-    var text = result[3];
+    var text = result[ task.type === Task.Types.HASHTAG ? 3 : 5 ];
     var taskText = this.trimCodeBlockEnd(text);
     if (task.id == getTaskId(self.getPath(), line, taskText)) {
       var index = result.index;
@@ -466,11 +468,9 @@ File.prototype.modifyCodeOrHashTask = function(re, task) {
         } else text = task.text;
       } else text = task.text;
       var hash = task.type === Task.Types.HASHTAG ? "#" : "";
+      var order = task.order === "" ? "" : util.format( "%d", task.order );
       var taskContent;
-      if ( task.order !== "" )
-        taskContent = util.format("%s%s:%d %s", hash, task.list, task.order, text);
-      else
-        taskContent = util.format("%s%s %s", hash, task.list, text);
+      taskContent = util.format("%s%s%s%s %s", hash, task.list, task.hasColon ? ":" : "", order, text);
       this.setContent(beforeContent + taskContent + afterContent);
       this.setModified(true);
       // task.type = Task.Types.HASHTAG;

--- a/lib/file.js
+++ b/lib/file.js
@@ -48,11 +48,11 @@ function File(opts) {
 }
 util.inherits(File, events.EventEmitter);
 
-var LINK_STYLE_REGEX = File.LINK_STYLE_REGEX = /\[(.+?)\]\(#([\w\-]+?):(\d+?\.?\d*?)\)/gm;
+var LINK_STYLE_REGEX = File.LINK_STYLE_REGEX = /\[(.+?)\]\(#([\w\-]+?)((:)(\d+?\.?\d*?)?)?\)/gm;
 var CODE_BLOCK_REGEX = File.CODE_BLOCK_REGEX = /`{3}[\s\S]*?`{3}/gm;
 var INLINE_CODE_REGEX = File.INLINE_CODE_REGEX = /`[\s\S]*?`/g;
 var CODE_STYLE_PATTERN = File.CODE_STYLE_PATTERN = "([A-Z-_]{2,})((:)(\\d+?\\.?\\d*?)?)?\\s+(.*)$";
-var HASH_STYLE_REGEX = File.HASH_STYLE_REGEX = /#([\w\-]+?):(\d+?\.?\d*?)\s+(.*)$/gm;
+var HASH_STYLE_REGEX = File.HASH_STYLE_REGEX = /#([\w\-]+?):(\d+?\.?\d*?)?\s+(.*)$/gm;
 
 var getTaskId = File.getTaskId = function(path, line, text) {
   var shasum = crypto.createHash('sha1');
@@ -329,8 +329,8 @@ File.prototype.extractCodeStyleTasks = function(config, pos, content) {
       var list = result[1];
       if (config && !config.includeList(list)) return; // #BACKLOG:20 Save all lists found so we can present them to the user
       var rawTask = result[0];
-      var hasColon = ( result[3] !== undefined );
-      var order = (result[4] === undefined) ? "" : parseFloat(result[4]);
+      var hasColon = ( result[3] !== undefined ) || ! (config && config.keepEmptyPriority );
+      var order = (result[4] === undefined) ? ( config && config.keepEmptyPriority ? "" : 0 ) : parseFloat(result[4]);
       var text = result[5];
       var line = this.getLineNumber(posInContent);
       var task = self.newTask(list, text, order, line, Task.Types.CODE, hasColon);
@@ -340,14 +340,14 @@ File.prototype.extractCodeStyleTasks = function(config, pos, content) {
   }
 };
 
-File.prototype.extractHashStyleTasks = function(pos, content) {
+File.prototype.extractHashStyleTasks = function(config, pos, content) {
   var self = this;
   var hashStyleRegex = new RegExp(HASH_STYLE_REGEX);
   var result;
   while((result = hashStyleRegex.exec(content)) !== null) {
     var list = result[1];
     var rawTask = result[0];
-    var order = (result[2] === undefined) ? "" : parseFloat(result[2]);
+    var order = (result[2] === undefined) ? ( config && config.keepEmptyPriority ? "" : 0 ) : parseFloat(result[2]);
     var text = result[3];
     var line = this.getLineNumber(result.index + pos);
     var task = this.newTask(list, text, order, line, Task.Types.HASHTAG, true);
@@ -356,14 +356,15 @@ File.prototype.extractHashStyleTasks = function(pos, content) {
   }
 };
 
-File.prototype.extractLinkStyleTasks = function(pos, content) {
+File.prototype.extractLinkStyleTasks = function(config, pos, content) {
   var self = this;
   var linkStyleRegex = new RegExp(LINK_STYLE_REGEX);
   var result;
   while((result = linkStyleRegex.exec(content)) !== null) {
     var list = result[2];
     var rawTask = result[0];
-    var order = (result[3] === undefined) ? "" : parseFloat(result[3]);
+    var hasColon = ( result[4] !== undefined ) || ! (config && config.keepEmptyPriority );
+    var order = (result[5] === undefined) ? ( config && config.keepEmptyPriority ? "" : 0 ) : parseFloat(result[5]);
     var text = result[1];
     var line = this.getLineNumber(result.index + pos);
     log("*********************************************************");
@@ -381,15 +382,15 @@ File.prototype.extractTasksInCodeFile = function(config) {
   while ((result = commentRegex.exec(self.getContent())) !== null) {
     var comment = result[0];
     var commentStart = result.index;
-    self.extractHashStyleTasks(commentStart, comment);
-    self.extractLinkStyleTasks(commentStart, comment);
+    self.extractHashStyleTasks(config, commentStart, comment);
+    self.extractLinkStyleTasks(config, commentStart, comment);
     self.extractCodeStyleTasks(config, commentStart, comment);
   }
 };
 
-File.prototype.extractTasksInNonCodeFile = function() {
-  this.extractHashStyleTasks(0, this.getContent());
-  this.extractLinkStyleTasks(0, this.getContent());
+File.prototype.extractTasksInNonCodeFile = function(config) {
+  this.extractHashStyleTasks(config, 0, this.getContent());
+  this.extractLinkStyleTasks(config, 0, this.getContent());
 };
 
 File.hasWindowsEOL = function(content) {
@@ -537,7 +538,7 @@ File.prototype.extractTasks = function(config) {
   if (this.isCodeFile()) {
     this.extractTasksInCodeFile(config);
   } else {
-    this.extractTasksInNonCodeFile();
+    this.extractTasksInNonCodeFile(config);
   }
   return this;
 };

--- a/lib/project.js
+++ b/lib/project.js
@@ -577,7 +577,8 @@ function moveTask(project, task, newList, newPos, cb) {
   async.series(_.map(toListTasks, function(_task, index) {
     return function(cb) {
       var repo = project.getRepoForTask(_task);
-      _task.order = index*10;
+      if ( _task.order !== "" )
+        _task.order = index*10;
       log("Task... text:%s list:%s order:%d path:%s id:%d", _task.text, _task.list, _task.order, _task.source.path, _task.id);
       repo.modifyTask(_task, cb);
     };
@@ -593,7 +594,8 @@ function moveTask(project, task, newList, newPos, cb) {
       async.series(_.map(fromListTasks, function(_task, index) {
         return function(cb) {
           var repo = project.getRepoForTask(_task);
-          _task.order = index*10;
+          if ( _task.order !== "" )
+            _task.order = index*10;
           repo.modifyTask(_task, cb);
         };
       }), cb);

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -906,7 +906,8 @@ Repository.prototype.moveTasks = function(tasks, newList, newPos, cb) {
     // Modify the tasks in current list
     async.series(_.map(toListTasks, function(_task, index) {
       return function(cb) {
-        _task.order = index*10;
+        if ( _task.order !== "" )
+          _task.order = index*10;
         self.modifyTask(_task, cb);
       };
     }), function(err, results) {
@@ -920,7 +921,8 @@ Repository.prototype.moveTasks = function(tasks, newList, newPos, cb) {
 
         async.series(_.map(fromListTasks, function(_task, index) {
           return function(cb) {
-            _task.order = index*10;
+            if ( _task.order !== "" )
+              _task.order = index*10;
             self.modifyTask(_task, cb);
           };
         }), cb);

--- a/lib/task.js
+++ b/lib/task.js
@@ -15,6 +15,7 @@ function Task(obj) {
   this.text = obj.text;
   this.list = obj.list;
   this.order = obj.order;
+  this.hasColon = obj.hasColon;
   this.line = obj.line;
   this.id = obj.id;
   this.repoId = obj.repoId;


### PR DESCRIPTION
This an attempt to treat priorities as optional parts of tasks.  Tasks without a priority (ie `order`) have their `order` set to an empty string (instead of `0`).  When `order` is updated, we skip those that are just an empty string, and when tasks are modified or output, we skip the `:<order>` part of the format string for tasks whose order is an empty string.

I'm not very familiar with Grunt, and I was not able to figure out to make new tests for this, but all existing tests appear to pass and using this with `imdone-atom` within Atom seemed to work: tasks with no priority were left with no priority when they were moved between lists and tasks with priority were updated correctly.