### PR TITLE
find tags/contexts at the start of a task, also disallow empty contexts

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -36,25 +36,25 @@ Task.Types = {
   MARKDOWN: "MARKDOWN"
 };
 
-Task.TagsRegExp = /\s\+(\S+)/gi;
+Task.TagsRegExp = /(^|\s)\+(\S+)/gi;
 Task.getTags = function(text) {
   var tags, result, re = new RegExp(Task.TagsRegExp);
 
   while ((result = re.exec(text)) !== null) {
     if (!tags) tags = [];
-    tags.push(result[1]);
+    tags.push(result[2]);
   }
 
   return tags;
 };
 
-Task.ContextRegExp = /\s\@(\w*)/gi;
+Task.ContextRegExp = /(^|\s)\@(\w+)/gi;
 Task.getContext = function(text) {
   var context, result, re = new RegExp(Task.ContextRegExp);
 
   while ((result = re.exec(text)) !== null) {
     if (!context) context = [];
-    context.push(result[1]);
+    context.push(result[2]);
   }
 
   return context;


### PR DESCRIPTION
This updates the regexps for tags and contexts so that they can be recognized at the start of a task.  Also, I changed `*` to `+` in the regexp for contexts in order to disallow contexts with empty names.

I tend to write tasks with tags and contexts interspersed, eg `TODO: +email not working at @checkout` so it's nice to have these recognized everywhere in the task string.