### PR TITLE
fix umlauts and special characters in contexts

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -49,7 +49,7 @@ Task.getTags = function(text) {
   return tags;
 };
 
-Task.ContextRegExp = /(^|\s)\@(\w+)/gi;
+Task.ContextRegExp = /(^|\s)\@(\S+)/gi;
 Task.getContext = function(text) {
   var context, result, re = new RegExp(Task.ContextRegExp);
 


### PR DESCRIPTION
Prior to this change, umlauts and other special characters would not be allowed in contexts.

For example, the task "#TODO: contact @Müller" would be detected to include the context "M" instead of "Müller". Similarly, ""#TODO: contact @Hans_Müller" would be detected as containing "Hans" instead of "Hans_Müller".

By matching against any non-space characters - similar to the tags regex - this change fixes the above issues.