### PR TITLE
Add Idris to supported languages

### DIFF
--- a/lib/languages.js
+++ b/lib/languages.js
@@ -30,6 +30,7 @@ module.exports = {
   ".hh":          {"name": "cpp", "symbol": "//", "block": cBlock},
   ".ino":         {"name": "cpp", "symbol": "//", "block": cBlock},
   ".php":         {"name": "php", "symbol": "//", "block": htmlBlock},
+  ".idr":         {"name": "idris", "symbol": "--"},
   ".hs":          {"name": "haskell", "symbol": "--"},
   ".erl":         {"name": "erlang", "symbol": "%"},
   ".hrl":         {"name": "erlang", "symbol": "%"},


### PR DESCRIPTION
Adds Idris https://www.idris-lang.org to the language list.