### PR TITLE
Exclude the `flow-typed` directory by default

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 var path = require('path');
 
-var DEFAULT_EXCLUDE_PATTERN = "^(node_modules|bower_components|\\.imdone|target|build|dist|logs)[\\/\\\\]?|\\.(git|svn|hg|npmignore)|\\~$|\\.(jpg|png|gif|swp|ttf|otf)$";
+var DEFAULT_EXCLUDE_PATTERN = "^(node_modules|bower_components|\\.imdone|target|build|dist|logs|flow-typed)[\\/\\\\]?|\\.(git|svn|hg|npmignore)|\\~$|\\.(jpg|png|gif|swp|ttf|otf)$";
 var CONFIG_DIR = ".imdone";
 module.exports = {
   ASYNC_LIMIT: 512,


### PR DESCRIPTION
After adding imdone to my project I got a lot of entries from library definitions inside of the `flow-typed` directory. This should fix the problem for the next person :)