### PR TITLE
Add support for ReasonML files

### DIFF
--- a/lib/languages.js
+++ b/lib/languages.js
@@ -106,5 +106,6 @@ module.exports = {
   ".cmp":         {"name": "lightning component", "symbol": "//", "block": htmlBlock },
   ".vm":          {"name": "velocity", "symbol": "##", "block": {"start": "#**", "end": "*#", "ignore": "*"} },
   ".vue":         {"name": "vue component", "symbol": "//", "block": cBlock},
-  ".lock":        {"name": "yarn lock", "symbol": "#"}
+  ".lock":        {"name": "yarn lock", "symbol": "#"},
+  ".re":         {"name": "reasonml", "block": cBlock},
 };


### PR DESCRIPTION
:wave:

ReasonML doesn't have single line comments, only block comments. I didn't notice any other language missing a `symbol` field so I figured I'd mention it.