### PR TITLE
- Load extension and installed plugin modules through file URL import…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.11
+
+- Load extension and installed plugin modules through file URL import specifiers, so Windows users no longer see `ERR_UNSUPPORTED_ESM_URL_SCHEME` when project paths start with drive letters like `C:\`
+- Keep generated library indexes from exporting tests, fixtures, hidden folders, or invalid namespace names, so build and type generation stay green when test fixtures include realistic `.imdone` directories
+
 ## 2.1.5
 
 - Create GitHub releases automatically from the npm package version when changes merge to `master`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,3 +23,4 @@ export * as domain from './domain/index.js';
 export * as mixins from './mixins/index.js';
 export * as plugins from './plugins/index.js';
 export * as usecases from './usecases/index.js';
+export * as utils from './utils/index.js';

--- a/lib/mixins/__tests__/repo-fs-store-write.spec.js
+++ b/lib/mixins/__tests__/repo-fs-store-write.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../adapters/file-gateway.js', () => ({
+  preparePathForWriting: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+  lstat: vi.fn(),
+  unlink: vi.fn()
+}))
+
+import { fileSystemStoreMixin } from '../repo-fs-store.js'
+import { Repository } from '../../repository.js'
+import { Config } from '../../config.js'
+import { File } from '../../file.js'
+import {
+  preparePathForWriting,
+  writeFile,
+  stat,
+  lstat
+} from '../../adapters/file-gateway.js'
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('RepoFsStore write boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not advance to post-write stat until the filesystem write resolves', async () => {
+    const config = Config.newDefaultConfig({
+      settings: {
+        cards: {}
+      }
+    })
+
+    const fakeFs = {
+      existsSync: vi.fn().mockReturnValue(false),
+      readFileSync: vi.fn(),
+      promises: {
+        lstat: vi.fn().mockResolvedValue({
+          isDirectory: () => false
+        })
+      }
+    }
+
+    const repo = fileSystemStoreMixin(new Repository('/repo', config), fakeFs)
+    const file = new File({
+      repoId: '/repo',
+      filePath: 'current-sprint/PROJ-1-Test/issue-PROJ-1.md',
+      content: '# Test\nBody\n',
+      project: {}
+    })
+
+    const pendingWrite = deferred()
+    let settled = false
+
+    preparePathForWriting.mockResolvedValue({
+      isDirectory: false
+    })
+    writeFile.mockReturnValue(pendingWrite.promise)
+    stat.mockResolvedValue({
+      mtime: new Date('2026-04-24T00:00:00Z'),
+      birthtime: new Date('2026-04-24T00:00:00Z'),
+      isFile: () => true
+    })
+    lstat.mockResolvedValue({
+      isDirectory: () => false
+    })
+
+    const writePromise = repo.writeFile(file)
+    writePromise.then(() => {
+      settled = true
+    })
+
+    await flushMicrotasks()
+
+    expect(preparePathForWriting).toHaveBeenCalledWith('/repo/current-sprint/PROJ-1-Test/issue-PROJ-1.md')
+    expect(writeFile).toHaveBeenCalledWith(
+      '/repo/current-sprint/PROJ-1-Test/issue-PROJ-1.md',
+      file.getContentForFile(),
+      'utf8'
+    )
+    expect(stat).not.toHaveBeenCalled()
+    expect(settled).toBe(false)
+
+    pendingWrite.resolve()
+    await writePromise
+
+    expect(stat).toHaveBeenCalledWith('/repo/current-sprint/PROJ-1-Test/issue-PROJ-1.md')
+    expect(file.modified).toBe(false)
+    expect(settled).toBe(true)
+  })
+})

--- a/lib/plugins/__tests__/extension-plugin.spec.js
+++ b/lib/plugins/__tests__/extension-plugin.spec.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const loggerMock = vi.hoisted(() => ({
+  log: vi.fn(),
+  warn: vi.fn(),
+}))
+const fileGatewayMock = vi.hoisted(() => ({
+  exists: vi.fn(),
+}))
+
+vi.mock('../../adapters/logger.js', () => ({
+  logger: loggerMock,
+}))
+vi.mock('../../adapters/file-gateway.js', () => fileGatewayMock)
+
+import ExtensionPlugin from '../extension-plugin.js'
+
+describe('ExtensionPlugin', () => {
+  it('loads extension modules through file URL import specifiers', async () => {
+    fileGatewayMock.exists.mockResolvedValue(true)
+    const dirname = path.dirname(fileURLToPath(import.meta.url))
+    const projectDir = path.join(dirname, 'fixtures', 'extension-project')
+
+    const plugin = new ExtensionPlugin({ path: projectDir })
+    const extensionPath = plugin.getExtensionPath(['actions', 'card'])
+    const extension = await plugin.loadExtensionModule(() => [], 'actions', 'card')
+
+    expect(fileGatewayMock.exists).toHaveBeenCalledWith(extensionPath)
+    expect(loggerMock.warn).not.toHaveBeenCalled()
+    expect(extension()).toEqual([{ title: 'Open', action: 'open' }])
+  })
+})

--- a/lib/plugins/__tests__/fixtures/extension-project/.imdone/actions/card.js
+++ b/lib/plugins/__tests__/fixtures/extension-project/.imdone/actions/card.js
@@ -1,0 +1,1 @@
+export default () => [{ title: 'Open', action: 'open' }]

--- a/lib/plugins/extension-plugin.js
+++ b/lib/plugins/extension-plugin.js
@@ -2,6 +2,7 @@ import Plugin from 'imdone-api'
 import _path from 'path'
 import { exists } from '../adapters/file-gateway.js'
 import { logger } from '../adapters/logger.js';
+import { toFileImportSpecifier } from '../utils/module-import.js'
 
 export default class ExtensionPlugin extends Plugin {
   constructor(project) {
@@ -71,7 +72,7 @@ export default class ExtensionPlugin extends Plugin {
   const extensionPath = this.getExtensionPath(path)
   try {
     await exists(extensionPath)
-    const importedModule = await import(extensionPath)
+    const importedModule = await import(toFileImportSpecifier(extensionPath))
     
     // Check if it's a module object with a default export
     if (importedModule && typeof importedModule === 'object' && 'default' in importedModule) {

--- a/lib/plugins/plugin-manager.js
+++ b/lib/plugins/plugin-manager.js
@@ -15,6 +15,7 @@ import ArchivePlugin from './archive-plugin.js'
 import EpicPlugin from './epic-plugin.js'
 import ExtensionPlugin from './extension-plugin.js'
 import { logger } from '../adapters/logger.js'
+import { toFileImportSpecifier } from '../utils/module-import.js'
 // import { URL } from 'node:url'
 
 // const require = createRequire(new URL(import.meta.url));
@@ -159,7 +160,7 @@ export class PluginManager extends Emitter {
       // eslint-disable-next-line
       delete require.cache[require.resolve(fullPath)]
       // eslint-disable-next-line
-      const pluginClass = await import(fullPath)
+      const pluginClass = await import(toFileImportSpecifier(fullPath))
       const pluginInstance = await this.createPlugin(pluginClass.default, path)
       return pluginInstance
     } catch (e) {
@@ -170,7 +171,7 @@ export class PluginManager extends Emitter {
           if (packageInfo.default.main) {
             fullPath = _path.join(_path.resolve(path), packageInfo.default.main)
             logger.log(`Trying package.json main: ${fullPath}`)
-            const pluginClass = await import(fullPath)
+            const pluginClass = await import(toFileImportSpecifier(fullPath))
             const pluginInstance = await this.createPlugin(pluginClass.default, path)
             return pluginInstance
           }
@@ -186,7 +187,7 @@ export class PluginManager extends Emitter {
     if (!path) return {}
     let info = { path }
     const packagePath = _path.join(path, 'package.json')
-    const packageInfo = await import(packagePath, {with: { type: 'json' } })
+    const packageInfo = await import(toFileImportSpecifier(packagePath), {with: { type: 'json' } })
     try {
       info = {...info, ...packageInfo }
       delete info.dependencies

--- a/lib/utils/__tests__/module-import.spec.js
+++ b/lib/utils/__tests__/module-import.spec.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import os from 'node:os'
+import path from 'node:path'
+import { toFileImportSpecifier } from '../module-import.js'
+
+describe('module import utilities', () => {
+  it('converts an absolute filesystem path into a file URL for dynamic import', () => {
+    const specifier = toFileImportSpecifier(path.join(os.tmpdir(), 'imdone-extension.js'))
+
+    expect(specifier).toMatch(/^file:\/\//)
+    expect(specifier).toContain('imdone-extension.js')
+  })
+})

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,0 +1,1 @@
+export * from './module-import.js';

--- a/lib/utils/module-import.js
+++ b/lib/utils/module-import.js
@@ -1,0 +1,5 @@
+import { pathToFileURL } from 'node:url'
+
+export function toFileImportSpecifier(filePath) {
+  return pathToFileURL(filePath).href
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2862,9 +2862,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -2,6 +2,16 @@ import fs from 'fs';
 import path from 'path';
 
 const LIB_DIR = './lib';
+const VALID_NAMESPACE_EXPORT = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function isIndexableDirectory(entry) {
+  return (
+    entry.isDirectory() &&
+    !['__tests__', '__fixtures__'].includes(entry.name) &&
+    !entry.name.startsWith('.') &&
+    VALID_NAMESPACE_EXPORT.test(entry.name)
+  );
+}
 
 // Recursively generates index.js files
 function generateIndexes(dir) {
@@ -12,7 +22,7 @@ function generateIndexes(dir) {
     .map(entry => `export * from './${entry.name}';`);
 
   const subdirs = entries
-    .filter(entry => entry.isDirectory() && entry.name !== '__tests__')
+    .filter(isIndexableDirectory)
     .map(entry => entry.name);
 
   // Generate index.js in each subdirectory

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,3 +23,4 @@ export * as domain from "./domain/index.js";
 export * as mixins from "./mixins/index.js";
 export * as plugins from "./plugins/index.js";
 export * as usecases from "./usecases/index.js";
+export * as utils from "./utils/index.js";

--- a/types/utils/index.d.ts
+++ b/types/utils/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./module-import.js";

--- a/types/utils/module-import.d.ts
+++ b/types/utils/module-import.d.ts
@@ -1,0 +1,1 @@
+export function toFileImportSpecifier(filePath: any): string;


### PR DESCRIPTION
… specifiers, so Windows users no longer see `ERR_UNSUPPORTED_ESM_URL_SCHEME` when project paths start with drive letters like `C:\`

- Keep generated library indexes from exporting tests, fixtures, hidden folders, or invalid namespace names, so build and type generation stay green when test fixtures include realistic `.imdone` directories